### PR TITLE
Add ability to deploy edigen to emuStudio repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,13 @@
     </dependencies>
     
     <build>
+        <extensions>
+            <extension>
+                <groupId>org.apache.maven.wagon</groupId>
+                <artifactId>wagon-ssh</artifactId>
+                <version>2.2</version>
+            </extension>
+        </extensions>
         <plugins>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -63,4 +70,12 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <netbeans.hint.license>gpl20</netbeans.hint.license>
     </properties>
+
+    <distributionManagement>
+        <repository>
+            <id>emustudio-repository</id>
+            <name>emuStudio Repository</name>
+            <url>sftp://web.sourceforge.net:/home/project-web/emustudio/htdocs/repository</url>
+        </repository>
+    </distributionManagement>    
 </project>


### PR DESCRIPTION
The edigen is needed as dependency for edigen-maven-plugin. And it would be good to have it at emuStudio repository.
