### PR TITLE
Fixed disassembler template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Edigen - Emulator Disassembler Generator
 ========================================
-[![Build Status](https://travis-ci.org/vbmacher/edigen.png)](https://travis-ci.org/vbmacher/edigen)
+[![Build Status](https://travis-ci.org/sulir/edigen.png)](https://travis-ci.org/sulir/edigen)
 
 Edigen is a command-line tool which generates Java source code of:
  * an instruction decoder of an emulator

--- a/src/main/resources/Disassembler.edt
+++ b/src/main/resources/Disassembler.edt
@@ -19,8 +19,8 @@ public class %disasm_class% extends AbstractDisassembler {
     * An instruction mnemonic format string with associated values.
     */
     private static class MnemonicFormat {
-        private String format;
-        private int[] values;
+        private final String format;
+        private final int[] values;
 
         public MnemonicFormat(String format, int[] values) {
             this.format = format;
@@ -39,7 +39,7 @@ public class %disasm_class% extends AbstractDisassembler {
     private static final boolean LITTLE_ENDIAN = true;
 
     private static final Map<Set<Integer>, MnemonicFormat> formatMap;
-    private MemoryContext memory;
+    private final MemoryContext memory;
 
     static {
         String[] formats = {
@@ -102,7 +102,7 @@ public class %disasm_class% extends AbstractDisassembler {
             code = codeBuilder.toString();
         } catch (InvalidInstructionException ex) {
             mnemonic = "unknown";
-            code = String.format("%02X", (Byte) memory.read(memoryPosition));
+            code = String.format("%02X", memory.read(memoryPosition));
         }
         
         return new DisassembledInstruction(memoryPosition, mnemonic, code);


### PR DESCRIPTION
See vbmacher/emuStudio#62. It is caused by invalid casting of `memory.read()` to `java.lang.Byte` if invalid instruction appears. You cannot know of what type a memory cell is. In most cases it is a `java.lang.Short`, but it might be anything else.
