### PR TITLE
[#4] Generate missing subrules with length specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,6 @@ src_reg, dst_reg =
     "X": 00 |
     "Y": 01;
 
-immediate = imm: imm(10);
-
 %%
 
 # disassembler

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>net.emustudio</groupId>
     <artifactId>edigen</artifactId>
-    <version>1.3</version>
+    <version>1.4-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Edigen</name>
     <description>Emulator Disassembler Generator</description>
@@ -58,7 +58,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>3.2.0</version>
+                        <version>3.2.1</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -72,7 +72,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.1.1</version>
+                        <version>3.3.0</version>
                         <configuration>
                             <excludePackageNames>net.emustudio.edigen.parser</excludePackageNames>
                             <source>8</source>
@@ -90,7 +90,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
+                        <version>3.0.1</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>

--- a/src/main/java/net/emustudio/edigen/ui/Argument.java
+++ b/src/main/java/net/emustudio/edigen/ui/Argument.java
@@ -38,7 +38,7 @@ public class Argument {
      * If {@code arg1} is a mandatory argument, {@code -arg2 value2} is a
      * value and {@code -arg3} is a flag, this is an example of a valid
      * command line input:
-     * <pre><kbd>program arg1 -arg2 value2 -arg3</kbd></pre>
+     * <pre>program arg1 -arg2 value2 -arg3</pre>
      * The order of value and flag arguments is irrelevant. Mandatory arguments
      * must occur in the specified order, but they can interleave with other
      * parameters.

--- a/src/test/java/net/emustudio/edigen/passes/ResolveNamesVisitorTest.java
+++ b/src/test/java/net/emustudio/edigen/passes/ResolveNamesVisitorTest.java
@@ -23,6 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * Test of the ResolveNamesVisitor class.
@@ -81,6 +82,15 @@ public class ResolveNamesVisitorTest {
         variant.addChild(new Subrule("nonexistent"));
 
         decoder.accept(new ResolveNamesVisitor());
+    }
+
+    @Test
+    public void testSubruleRefersToNonexistentRuleWithLength() throws SemanticException {
+        Subrule subrule = new Subrule("nonexistent", 10, null);
+        variant.addChild(subrule);
+
+        decoder.accept(new ResolveNamesVisitor());
+        assertNotNull(subrule.getRule());
     }
 
     @Test


### PR DESCRIPTION
The following now should work:

```
instruction = "JMP": line(5)     ignore8(8) 000 ignore16(16);

%%

"%s %d" = instruction line ignore8 ignore16;
```

(no exceptions)
