### PR TITLE
[#80] Avoid mutating decoded operands during disassembly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,6 +99,8 @@ test {
 
 javadoc {
   exclude 'net/emustudio/edigen/parser/**'
+  options.addStringOption('Xdoclint:all,-missing', '-quiet')
+  options.memberLevel = JavadocMemberLevel.PROTECTED
   if (JavaVersion.current().isJava9Compatible()) {
     options.addBooleanOption('html5', true)
   }

--- a/src/main/java/net/emustudio/edigen/generation/GenerateMethodsVisitor.java
+++ b/src/main/java/net/emustudio/edigen/generation/GenerateMethodsVisitor.java
@@ -170,7 +170,7 @@ public class GenerateMethodsVisitor extends Visitor {
 
             if (variant.getReturnString() != null) {
                 value = '"' + variant.getReturnString() + "\", " + variant.getFieldName();
-                put(String.format("instruction.add(%s, %s);", field, value));
+                put(String.format("addInstruction(%s, %s);", field, value));
             } else {
                 int start = variant.getReturnSubrule().getStart();
                 int length = variant.getReturnSubrule().getLength();
@@ -188,7 +188,7 @@ public class GenerateMethodsVisitor extends Visitor {
                 } else {
                     value = String.format("readBits(start + %d, %d)", start, length);
                 }
-                put(String.format("instruction.add(%s, %s, %d);", field, value, length));
+                put(String.format("addInstruction(%s, %s, %d);", field, value, length));
             }
         }
 

--- a/src/main/java/net/emustudio/edigen/generation/GenerateParametersVisitor.java
+++ b/src/main/java/net/emustudio/edigen/generation/GenerateParametersVisitor.java
@@ -12,7 +12,6 @@ import net.emustudio.edigen.nodes.Value;
 import java.io.PrintWriter;
 import java.io.Writer;
 import java.util.Iterator;
-import java.util.stream.Collectors;
 
 /**
  * A visitor which generates the code of the two-dimensional array of
@@ -81,10 +80,28 @@ public class GenerateParametersVisitor extends Visitor {
      */
     @Override
     public void visit(Value value) throws SemanticException {
-        String strategies = value.getStrategies().stream()
-                .map(s -> "Strategy." + s)
-                .collect(Collectors.joining(", "));
+        StringBuilder strategies = new StringBuilder();
+        for (String strategy : value.getStrategies()) {
+            strategies.append(findBitOperationForStrategy(strategy, value));
+        }
+
         writer.print("new Parameter(" + value.getFieldName()
-                + ", new byte[]{" + strategies + "})");
+                + ", BitOperations.builder()" + strategies + ")");
+    }
+
+    private String findBitOperationForStrategy(String strategy, Value value) throws SemanticException {
+        switch (strategy) {
+            case "reverse_bytes":
+                return ".reverseBytes()";
+            case "bit_reverse":
+                return ".reverseBits()";
+            case "absolute":
+                return ".absolute()";
+            case "shift_left":
+                return ".shiftLeft()";
+            case "shift_right":
+                return ".shiftRight()";
+        }
+        throw new SemanticException("Unknown disassembler strategy: " + strategy, value);
     }
 }

--- a/src/main/resources/Decoder.edt
+++ b/src/main/resources/Decoder.edt
@@ -19,6 +19,19 @@ public class %decoder_class% implements Decoder {
     private static final int INITIAL_BUFFER_SIZE = 8;
     private static final long UNSIGNED_INT_MASK = 0xFFFFFFFFL;
 
+    // A rule key can carry the constant decoded from a string-returning variant.
+    private static final byte HAS_CONSTANT = 1;
+
+    // A rule key can carry the original string returned by a named variant.
+    private static final byte HAS_STRING = 2;
+
+    // A rule key can carry raw operand bits returned by a subrule.
+    private static final byte HAS_BITS = 4;
+
+    // Keep the default footprint small; sparse or high rule codes grow on demand.
+    private static final int INITIAL_KEY_CAPACITY = 8;
+
+
     private byte[] instructionBytes = new byte[INITIAL_BUFFER_SIZE];
     private final MemoryContext<? extends Number> memory;
 
@@ -26,7 +39,15 @@ public class %decoder_class% implements Decoder {
     private int loadedInstructionBytes;
     private int unit;
     private int bitsRead;
-    private DecodedInstruction instruction;
+
+    private byte[] keyStates = new byte[INITIAL_KEY_CAPACITY];
+    private int[] constants = new int[INITIAL_KEY_CAPACITY];
+    private String[] strings = new String[INITIAL_KEY_CAPACITY];
+    private int[] bitValues = new int[INITIAL_KEY_CAPACITY];
+    private int[] bitLengths = new int[INITIAL_KEY_CAPACITY];
+    private int[] keys = new int[INITIAL_KEY_CAPACITY];
+
+    private int keyCount;
 
     /**
      * LRU cache of decoded instructions keyed by memory position.
@@ -68,7 +89,7 @@ public class %decoder_class% implements Decoder {
 
         DecodedInstruction entry = cache.get(memoryPosition);
         if (entry != null) {
-            byte[] cachedBytes = entry.getImage();
+            byte[] cachedBytes = entry.image;
             Number[] currentBytes = memory.read(memoryPosition, cachedBytes.length);
             if (matchesCachedBytes(cachedBytes, currentBytes)) {
                 return entry;
@@ -77,13 +98,16 @@ public class %decoder_class% implements Decoder {
             loadedInstructionBytes = currentBytes.length;
         }
 
-        instruction = new DecodedInstruction();
-        bitsRead = 0;
+        reset();
         %root_rule%;
 
         int imageLength = Math.max(1, (bitsRead + 7) >>> 3);
         byte[] image = Arrays.copyOf(instructionBytes, imageLength);
-        instruction.setImage(image);
+
+        DecodedInstruction instruction = new DecodedInstruction(
+            image, keyCount, keyStates, constants, strings, bitValues, bitLengths
+        );
+
         cache.put(memoryPosition, instruction);
         return instruction;
     }
@@ -161,6 +185,78 @@ public class %decoder_class% implements Decoder {
         int shift = ((endByte - startByte) << 3) - (start & 0x7) - length;
         long mask = (length == 32) ? UNSIGNED_INT_MASK : ((1L << length) - 1L);
         return (int) ((value >>> shift) & mask);
+    }
+
+    /**
+     * Resets the decoder state for a new instruction.
+     */
+    private void reset() {
+        bitsRead = 0;
+        keyStates = new byte[INITIAL_KEY_CAPACITY];
+        constants = new int[INITIAL_KEY_CAPACITY];
+        strings = new String[INITIAL_KEY_CAPACITY];
+        bitValues = new int[INITIAL_KEY_CAPACITY];
+        bitLengths = new int[INITIAL_KEY_CAPACITY];
+        keys = new int[INITIAL_KEY_CAPACITY];
+        keyCount = 0;
+    }
+
+    /**
+     * Adds instruction: string-returning variant
+     *
+     * @param key      the key (rule code)
+     * @param string   the string which the recognized variant returned
+     * @param constant the constant obtained from the string
+     */
+    private void addInstruction(int key, String string, int constant) {
+        ensureKeyCapacity(key);
+        if (keyStates[key] == 0) {
+            rememberKey(key);
+        }
+        keyStates[key] |= HAS_CONSTANT | HAS_STRING;
+        constants[key] = constant;
+        strings[key] = string;
+    }
+
+    /**
+     * Adds instruction: subrule-returning variant
+     *
+     * @param key    the rule code
+     * @param bits   the bit sequence in little-endian, padded to whole bytes
+     * @param length bit length (in bits)
+     */
+    private void addInstruction(int key, int bits, int length) {
+        ensureKeyCapacity(key);
+        if (keyStates[key] == 0) {
+            rememberKey(key);
+        }
+        keyStates[key] |= HAS_BITS;
+        bitValues[key] = bits;
+        bitLengths[key] = length;
+    }
+
+    private void rememberKey(int key) {
+        if (keyCount == keys.length) {
+            keys = Arrays.copyOf(keys, keyCount << 1);
+        }
+        keys[keyCount++] = key;
+    }
+
+    private void ensureKeyCapacity(int key) {
+        if (key < keyStates.length) {
+            return;
+        }
+
+        int newLength = keyStates.length;
+        while (newLength <= key) {
+            newLength <<= 1;
+        }
+
+        keyStates = Arrays.copyOf(keyStates, newLength);
+        constants = Arrays.copyOf(constants, newLength);
+        strings = Arrays.copyOf(strings, newLength);
+        bitValues = Arrays.copyOf(bitValues, newLength);
+        bitLengths = Arrays.copyOf(bitLengths, newLength);
     }
 
     %decoder_methods%

--- a/src/main/resources/Disassembler.edt
+++ b/src/main/resources/Disassembler.edt
@@ -4,6 +4,7 @@ package %disasm_package%;
 import net.emustudio.emulib.plugins.cpu.*;
 import net.emustudio.emulib.plugins.memory.MemoryContext;
 import net.emustudio.emulib.runtime.helpers.Bits;
+import net.emustudio.emulib.runtime.helpers.BitOperations;
 import net.emustudio.emulib.runtime.helpers.StringUtils;
 
 import java.util.*;
@@ -37,29 +38,15 @@ public class %disasm_class% implements Disassembler {
     */
     private static class Parameter {
         private final int ruleCode;
-        private final byte[] strategies;
+        private final BitOperations bitOperations;
 
-        public Parameter(int ruleCode, byte[] strategies) {
+        public Parameter(int ruleCode, BitOperations bitOperations) {
             this.ruleCode = ruleCode;
-            this.strategies = strategies;
+            this.bitOperations = bitOperations;
         }
 
         public int getRuleCode() { return ruleCode; }
-        public byte[] getStrategies() { return strategies; }
-    }
-
-    /**
-    * A class with constant-decoding strategies.
-    *
-    * If the value represents a number, a decoding method should return bytes in
-    * the big-endian order since they will be used in Java methods accepting big endian.
-    */
-    private static class Strategy {
-        public static final byte reverse_bytes = 1;
-        public static final byte bit_reverse = 2;
-        public static final byte absolute = 3;
-        public static final byte shift_left = 4;
-        public static final byte shift_right = 5;
+        public BitOperations getBitOperations() { return bitOperations; }
     }
 
     private static final Map<Set<Integer>, MnemonicFormat> formatMap;
@@ -123,7 +110,7 @@ public class %disasm_class% implements Disassembler {
                 return new DisassembledInstruction(memoryPosition, lastRenderedMnemonic, lastRenderedCode);
             }
 
-            MnemonicFormat format = formatMap.get(instruction.getKeys());
+            MnemonicFormat format = formatMap.get(getKeys(instruction));
 
             if (format == null) {
                 mnemonic = "N/A";
@@ -131,7 +118,7 @@ public class %disasm_class% implements Disassembler {
                 mnemonic = createMnemonic(instruction, format);
             }
 
-            code = formatImage(instruction.getImage());
+            code = formatImage(instruction.image);
             lastRenderedPosition = memoryPosition;
             lastRenderedDecodedInstruction = instruction;
             lastRenderedMnemonic = mnemonic;
@@ -153,10 +140,22 @@ public class %disasm_class% implements Disassembler {
     @Override
     public int getNextInstructionPosition(int memoryPosition) {
         try {
-            return memoryPosition + cachedDecode(memoryPosition).getLength();
+            return memoryPosition + cachedDecode(memoryPosition).image.length;
         } catch (InvalidInstructionException ex) {
             return memoryPosition + 1;
         }
+    }
+
+    private Set<Integer> getKeys(DecodedInstruction instruction) {
+        Set<Integer> keys = new HashSet<>(Math.max(1, instruction.keyCount));
+
+        for (int ruleCode = 0; ruleCode < instruction.strings.length && keys.size() < instruction.keyCount; ruleCode++) {
+            if (instruction.strings[ruleCode] != null || instruction.bits[ruleCode] != null) {
+                keys.add(ruleCode);
+            }
+        }
+
+        return keys;
     }
 
     /**
@@ -192,37 +191,18 @@ public class %disasm_class% implements Disassembler {
             }
 
             String replaced;
-            Bits value = instruction.getBits(parameter.getRuleCode());
+            Bits value = instruction.bits[parameter.getRuleCode()];
             if (value != null) {
-                for (byte strategy : parameter.getStrategies()) {
-                    value = applyStrategy(value, strategy);
-                }
+                value = parameter.getBitOperations().apply(value);
                 replaced = StringUtils.format(mnemonic.charAt(position + 1), value);
             } else {
-                replaced = instruction.getString(parameter.getRuleCode());
+                replaced = instruction.strings[parameter.getRuleCode()];
             }
 
             mnemonic.replace(position, position + 2, replaced);
         }
 
         return mnemonic.toString();
-    }
-
-    private Bits applyStrategy(Bits bits, byte strategy) {
-        switch (strategy) {
-            case Strategy.reverse_bytes:
-                return bits.reverseBytes();
-            case Strategy.bit_reverse:
-                return bits.reverseBits();
-            case Strategy.absolute:
-                return bits.absolute();
-            case Strategy.shift_left:
-                return bits.shiftLeft();
-            case Strategy.shift_right:
-                return bits.shiftRight();
-            default:
-                throw new IllegalArgumentException("Unknown decoding strategy: " + strategy);
-        }
     }
 
     private String formatImage(byte[] image) {

--- a/src/test/java/net/emustudio/edigen/generation/GeneratedInstructionSemanticsTest.java
+++ b/src/test/java/net/emustudio/edigen/generation/GeneratedInstructionSemanticsTest.java
@@ -20,19 +20,23 @@ public class GeneratedInstructionSemanticsTest {
                     + "instruction =\n"
                     + "    \"load\": 0x01 imm8 |\n"
                     + "    \"shift\": 0x02 shift8 |\n"
+                    + "    \"wide\": 0x03 imm16 |\n"
                     + "    \"op\": 1111 imm32(32) 0000;\n"
                     + "imm8 = imm8: imm8(8);\n"
                     + "shift8 = shift8: shift8(8);\n"
+                    + "imm16 = imm16: imm16(16);\n"
                     + "imm32 = imm32: imm32(32);\n"
                     + "%%\n"
                     + "\"%s %X\" = instruction imm8;\n"
                     + "\"%s %X\" = instruction shift8(shift_left);\n"
+                    + "\"%s %X\" = instruction imm16(reverse_bytes);\n"
                     + "\"%s %X\" = instruction imm32;\n";
 
     private static EdigenTestCompiler.Compiled compiled;
     private static int instructionKey;
     private static int imm8Key;
     private static int shift8Key;
+    private static int imm16Key;
     private static int imm32Key;
 
     private FakeByteMemory memory;
@@ -45,6 +49,7 @@ public class GeneratedInstructionSemanticsTest {
         instructionKey = getRuleCode("INSTRUCTION");
         imm8Key = getRuleCode("IMM8");
         shift8Key = getRuleCode("SHIFT8");
+        imm16Key = getRuleCode("IMM16");
         imm32Key = getRuleCode("IMM32");
     }
 
@@ -67,25 +72,22 @@ public class GeneratedInstructionSemanticsTest {
         memory.writeBytes(0x100, new byte[]{0x01, (byte) 0xAB});
 
         DecodedInstruction instruction = decoder.decode(0x100);
-        Bits bits = instruction.getBits(imm8Key);
+        Bits bits = instruction.bits[imm8Key];
 
-        assertTrue(instruction.hasKey(instructionKey));
-        assertTrue(instruction.hasKey(imm8Key));
-        assertEquals("load", instruction.getString(instructionKey));
+        assertEquals(2, instruction.keyCount);
+        assertEquals("load", instruction.strings[instructionKey]);
+        assertNotNull(instruction.bits[imm8Key]);
         assertNotNull(bits);
         assertEquals(0xAB, bits.number);
-        assertSame(bits, instruction.getBits(imm8Key));
-        assertEquals(2, instruction.getKeys().size());
-        assertTrue(instruction.getKeys().contains(instructionKey));
-        assertTrue(instruction.getKeys().contains(imm8Key));
-        assertEquals("load AB", disassembler.disassemble(0x100).getMnemo());
+        assertSame(bits, instruction.bits[imm8Key]);
+        assertEquals("load AB", disassembler.disassemble(0x100).mnemo);
     }
 
     @Test
     public void testGeneratedDisassemblerAppliesStrategies() throws Exception {
         memory.writeBytes(0x200, new byte[]{0x02, (byte) 0x81});
 
-        assertEquals("shift 2", disassembler.disassemble(0x200).getMnemo());
+        assertEquals("shift 2", disassembler.disassemble(0x200).mnemo);
     }
 
     @Test
@@ -94,15 +96,29 @@ public class GeneratedInstructionSemanticsTest {
         memory.writeBytes(0x300, image);
 
         DecodedInstruction instruction = decoder.decode(0x300);
-        Bits bits = instruction.getBits(imm32Key);
+        Bits bits = instruction.bits[imm32Key];
 
-        assertTrue(instruction.hasKey(instructionKey));
-        assertTrue(instruction.hasKey(imm32Key));
-        assertFalse(instruction.hasKey(shift8Key));
+        assertEquals(2, instruction.keyCount);
+        assertEquals("op", instruction.strings[instructionKey]);
+        assertNull(instruction.bits[shift8Key]);
         assertNotNull(bits);
         assertEquals(0x12345678, bits.number);
-        assertArrayEquals(image, instruction.getImage());
-        assertEquals("op 12345678", disassembler.disassemble(0x300).getMnemo());
+        assertArrayEquals(image, instruction.image);
+        assertEquals("op 12345678", disassembler.disassemble(0x300).mnemo);
+    }
+
+    @Test
+    public void testRepeatedDisassemblyDoesNotMutateDecodedOperands() throws Exception {
+        memory.writeBytes(0x220, new byte[]{0x03, 0x00, (byte) 0xFF});
+
+        DecodedInstruction instruction = decoder.decode(0x220);
+        Bits bits = instruction.bits[imm16Key];
+
+        assertEquals(0x00FF, bits.number);
+        assertEquals("wide FF00", disassembler.disassemble(0x220).mnemo);
+        assertEquals("wide FF00", disassembler.disassemble(0x220).mnemo);
+        assertEquals(0x00FF, bits.number);
+        assertEquals(0x00FF, instruction.bits[imm16Key].number);
     }
 
     private static int getRuleCode(String fieldName) throws Exception {

--- a/src/test/java/net/emustudio/edigen/generation/RecursiveRulesDecoderTest.java
+++ b/src/test/java/net/emustudio/edigen/generation/RecursiveRulesDecoderTest.java
@@ -55,12 +55,12 @@ public class RecursiveRulesDecoderTest {
         DecodedInstruction onePrefix = decoder.decode(0x200);
         DecodedInstruction twoPrefixes = decoder.decode(0x300);
 
-        assertEquals(1, noPrefix.getLength());
-        assertEquals(2, onePrefix.getLength());
-        assertEquals(3, twoPrefixes.getLength());
-        assertArrayEquals(new byte[]{(byte) 0xEF}, noPrefix.getImage());
-        assertArrayEquals(new byte[]{(byte) 0xFF, (byte) 0xEF}, onePrefix.getImage());
-        assertArrayEquals(new byte[]{(byte) 0xFF, (byte) 0xFF, (byte) 0xEF}, twoPrefixes.getImage());
+        assertEquals(1, noPrefix.image.length);
+        assertEquals(2, onePrefix.image.length);
+        assertEquals(3, twoPrefixes.image.length);
+        assertArrayEquals(new byte[]{(byte) 0xEF}, noPrefix.image);
+        assertArrayEquals(new byte[]{(byte) 0xFF, (byte) 0xEF}, onePrefix.image);
+        assertArrayEquals(new byte[]{(byte) 0xFF, (byte) 0xFF, (byte) 0xEF}, twoPrefixes.image);
     }
 
     @Test


### PR DESCRIPTION
- Use BitOperations instead of Strategy
- Move mutable state+methods from DecodedInstruction to Decoder edt